### PR TITLE
Add restart action

### DIFF
--- a/sshoot/main.py
+++ b/sshoot/main.py
@@ -78,6 +78,11 @@ class Sshoot(Script):
         manager.stop_profile(args.name)
         print(_("Profile stopped"))
 
+    def action_restart(self, manager: Manager, args: Namespace):
+        """Restart sshuttle for the specified profile."""
+        manager.restart_profile(args.name, extra_args=args.args)
+        print(_("Profile restarted"))
+
     def action_is_running(self, manager: Manager, args: Namespace):
         """Return whether the specified profile is running."""
         # raise an error if profile is unknown
@@ -206,6 +211,22 @@ class Sshoot(Script):
         complete_argument(
             stop_parser.add_argument("name", help=_("name of the profile to stop")),
             partial(profile_completer, running=True),
+        )
+
+        # Restart profile
+        restart_parser = subparsers.add_parser(
+            "restart", help=_("restart a VPN session for a profile")
+        )
+        complete_argument(
+            restart_parser.add_argument(
+                "name", help=_("name of the profile to restart")
+            ),
+            partial(profile_completer, running=True),
+        )
+        restart_parser.add_argument(
+            "args",
+            nargs="*",
+            help=("additional arguments passed to sshuttle command line."),
         )
 
         # Return whether profile is running

--- a/sshoot/manager.py
+++ b/sshoot/manager.py
@@ -118,6 +118,12 @@ class Manager:
                 _("Failed to stop profile: {error}").format(error=error)
             )
 
+    def restart_profile(self, name: str, extra_args: Optional[List[str]] = None):
+        """Restart profile with given name."""
+        if self.is_running(name):
+            self.stop_profile(name)
+        self.start_profile(name, extra_args=extra_args)
+
     def is_running(self, name: str) -> bool:
         """Return whether the specified profile is running."""
         pidfile = self._get_pidfile(name)

--- a/sshoot/tests/test_manager.py
+++ b/sshoot/tests/test_manager.py
@@ -214,6 +214,24 @@ class TestManager:
             profile_manager.stop_profile("profile")
         assert "Failed to stop profile" in str(err.value)
 
+    def test_restart_profile(
+        self, mocker, profile_manager, pid_file, profile, sessions_dir, bin_succeed
+    ):
+        """Manage.restart_profile restarts a running profile."""
+        profile_manager._get_executable = lambda: str(bin_succeed)
+        running_state = [True, True, False]
+        profile_manager.is_running = lambda name: running_state.pop(0)
+        mock_kill = mocker.patch("sshoot.manager.os.kill")
+        pid_file.write_text("100\n")
+
+        profile_manager.restart_profile("profile")
+
+        mock_kill.assert_called_once_with(100, 15)
+        cmdline = (bin_succeed.parent / "cmdline").read_text()
+        assert cmdline == (
+            "10.0.0.0/24 --daemon --pidfile {}/profile.pid\n".format(sessions_dir)
+        )
+
     def test_get_pidfile(self, profile_manager, pid_file):
         """Manager._get_pidfile returns the pidfile path for a session."""
         assert profile_manager._get_pidfile("profile") == pid_file


### PR DESCRIPTION
Add an option to stop and start a profile in one action.  This can be useful, for example, when an active profile becomes stale if the local system has gone to sleep.