### PR TITLE
Wait for old session to stop before restarting

### DIFF
--- a/sshoot/manager.py
+++ b/sshoot/manager.py
@@ -9,6 +9,7 @@ from subprocess import (
     Popen,
 )
 from tempfile import gettempdir
+import time
 from typing import (
     Any,
     cast,
@@ -122,6 +123,14 @@ class Manager:
         """Restart profile with given name."""
         if self.is_running(name):
             self.stop_profile(name)
+            # Give OS some time to process async SIGTERM on previous instance
+            # of the session
+            wait = 1
+            time.sleep(wait)
+            if self.is_running(name):
+                raise ManagerProfileError(
+                    _("Profile failed to stop after {wait} seconds").format(wait=wait)
+                )
         self.start_profile(name, extra_args=extra_args)
 
     def is_running(self, name: str) -> bool:


### PR DESCRIPTION
I should have tested before pushing the last time to my [previous pull request](https://github.com/albertodonato/sshoot/pull/8).  It takes a little time for the OS to process the `SIGTERM` on the previous session.  Otherwise, sshoot will try to start the new session before the old session has been terminated.

@albertodonato #8 will not work without this change.